### PR TITLE
Add restart on docker-compose.yml. Closes #50.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   client:
     build: ./client
+    restart: always
     volumes:
     - ./client:/opt/app
     - /opt/app/node_modules
@@ -12,6 +13,7 @@ services:
 
   server:
     build: ./server
+    restart: always
     volumes:
     - ./server:/opt/app
     - /opt/app/node_modules


### PR DESCRIPTION
# Add restart on docker-compose.yml

More information about the *restart* keyword introduced in the file can be found here: https://docs.docker.com/compose/compose-file/#restart

Fixes #50 .

The restart keyword on docker-compose allows the container to be restarted if it is not running AND was not manually stopped (using either docker stop or docker kill)

@mikefab please review.